### PR TITLE
Fix PDF viewer rendering on high-density displays

### DIFF
--- a/file-type-detector/handler_test.ts
+++ b/file-type-detector/handler_test.ts
@@ -193,10 +193,10 @@ describe('Handler Tests', () => {
             const matchedHandlers = HANDLERS.filter(h =>
                 h.mimetypes.some(m => matchMimetype(m, 'application/pdf', 'test.pdf'))
             );
-            expect(matchedHandlers.some(h => h.handler === 'pdfviewer')).toBe(true);
+            expect(matchedHandlers.some(h => h.handler === 'pdfjs')).toBe(true);
         });
 
-        it('gives pdfviewer precedence over browser for PDF files', () => {
+        it('gives pdfjs precedence over browser for PDF files', () => {
             const filename = 'test.pdf';
             const mime = 'application/pdf';
 
@@ -204,7 +204,7 @@ describe('Handler Tests', () => {
                 h.mimetypes.some(m => matchMimetype(m, mime, filename))
             );
 
-            const pdfViewerIndex = matchedHandlers.findIndex(h => h.handler === 'pdfviewer');
+            const pdfViewerIndex = matchedHandlers.findIndex(h => h.handler === 'pdfjs');
             const browserIndex = matchedHandlers.findIndex(h => h.handler === 'browser');
 
             expect(pdfViewerIndex).not.toBe(-1);

--- a/pdfjs/main.tsx
+++ b/pdfjs/main.tsx
@@ -52,7 +52,9 @@ function PDFPage({ pdf, pageNum }: { pdf: any, pageNum: number }) {
         const renderPage = async () => {
             try {
                 const page = await pdf.getPage(pageNum);
-                const viewport = page.getViewport({ scale: 1.5 });
+                const dpr = window.devicePixelRatio || 1;
+                const baseScale = 1.5;
+                const viewport = page.getViewport({ scale: baseScale * dpr });
                 const canvas = canvasRef.current;
                 if (!canvas) return;
                 const context = canvas.getContext('2d');
@@ -60,6 +62,8 @@ function PDFPage({ pdf, pageNum }: { pdf: any, pageNum: number }) {
 
                 canvas.height = viewport.height;
                 canvas.width = viewport.width;
+                canvas.style.height = `${viewport.height / dpr}px`;
+                canvas.style.width = `${viewport.width / dpr}px`;
 
                 const renderContext = {
                     canvasContext: context,

--- a/tests/integration/pdfviewer.spec.ts
+++ b/tests/integration/pdfviewer.spec.ts
@@ -11,7 +11,7 @@ test('PDF Viewer should correctly render a PDF file using PDF.js', async ({ page
     const pdfBuffer = fs.readFileSync(pdfPath);
 
     const iframe = await runHandlerTest(page, {
-        handler: 'pdfviewer',
+        handler: 'pdfjs',
         file: {
             content: pdfBuffer,
             name: 'test.pdf',


### PR DESCRIPTION
The PDF viewer was rendering blurry on high-density displays because it wasn't taking `devicePixelRatio` into account. I updated the rendering logic in `pdfjs/main.tsx` to scale the viewport and canvas dimensions accordingly. I also ensured that the handler and project names are consistent as `pdfjs` across the codebase and tests.

---
*PR created automatically by Jules for task [17217372112792975988](https://jules.google.com/task/17217372112792975988) started by @mauricelam*