### PR TITLE
Improve error message and UI for non-ext4 files in imgviewer

### DIFF
--- a/img-viewer/main.tsx
+++ b/img-viewer/main.tsx
@@ -23,6 +23,13 @@ const Ext4Viewer: React.FC = () => {
                 const data = new Uint8Array(buffer);
                 setFileData(data);
 
+                // ext4 magic number 0xEF53 at offset 1080 (0x438)
+                const isExt4 = data.length > 1081 && data[1080] === 0x53 && data[1081] === 0xEF;
+                if (!isExt4) {
+                    setError("This file does not appear to be a valid ext4 filesystem image.");
+                    return;
+                }
+
                 try {
                     setLoading(true);
                     const parsedTree = parse_ext4(data);
@@ -125,7 +132,51 @@ const Ext4Viewer: React.FC = () => {
     };
 
     if (error) {
-        return <div style={{ color: 'red', padding: '20px' }}>{error}</div>;
+        return (
+            <div style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                height: '100%',
+                padding: '20px',
+                textAlign: 'center',
+                color: '#333'
+            }}>
+                <div style={{ fontSize: '48px', marginBottom: '16px' }}>⚠️</div>
+                <h2 style={{ margin: '0 0 12px 0', color: '#d32f2f' }}>Error Loading Image</h2>
+                <div style={{
+                    backgroundColor: '#fdecea',
+                    color: '#d32f2f',
+                    padding: '12px 20px',
+                    borderRadius: '8px',
+                    maxWidth: '450px',
+                    fontSize: '14px',
+                    lineHeight: '1.5',
+                    border: '1px solid #f5c6cb'
+                }}>
+                    {error}
+                </div>
+                <button
+                    onClick={() => {
+                        setError(null);
+                        setTree(null);
+                        setFileData(null);
+                        window.parent.postMessage({ action: 'requestFile' });
+                    }}
+                    style={{
+                        marginTop: '20px',
+                        padding: '8px 16px',
+                        backgroundColor: '#f5f5f5',
+                        border: '1px solid #ddd',
+                        borderRadius: '4px',
+                        cursor: 'pointer'
+                    }}
+                >
+                    Try again
+                </button>
+            </div>
+        );
     }
 
     if (loading) {

--- a/tests/integration/imgviewer-error.spec.ts
+++ b/tests/integration/imgviewer-error.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+import { runHandlerTest } from './test-utils';
+
+test('img-viewer should show a helpful error for non-ext4 files', async ({ page }) => {
+    const fileBuffer = Buffer.from('this is not an ext4 image');
+    const iframe = await runHandlerTest(page, {
+        handler: 'img-viewer',
+        file: {
+            content: fileBuffer,
+            name: 'test.img',
+            type: 'application/octet-stream'
+        }
+    });
+
+    await expect(iframe.getByText('Error Loading Image')).toBeVisible();
+    await expect(iframe.getByText('This file does not appear to be a valid ext4 filesystem image.')).toBeVisible();
+});

--- a/tests/integration/imgviewer.spec.ts
+++ b/tests/integration/imgviewer.spec.ts
@@ -21,7 +21,7 @@ test('img-viewer should list files in an ext4 image', async ({ page }) => {
     });
 
     // Check if the explorer title is present
-    await expect(iframe.getByText('img Image Explorer')).toBeVisible();
+    await expect(iframe.getByText('ext4 Image Explorer')).toBeVisible();
 
     // Check for the hello.txt file we added to the image
     await expect(iframe.getByText('hello.txt')).toBeVisible();


### PR DESCRIPTION
Improved the user experience when loading non-ext4 files in the imgviewer. Added a magic number check for early detection and a styled error component with reset functionality. Updated integration tests to cover the new behavior.

---
*PR created automatically by Jules for task [440174498153616154](https://jules.google.com/task/440174498153616154) started by @mauricelam*