### PR TITLE
Fix SETools UI layout and tab styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1428,7 +1428,6 @@
             "version": "7.29.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1940,7 +1939,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -1962,7 +1960,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -3241,7 +3238,6 @@
         "node_modules/@mantine/hooks": {
             "version": "7.17.8",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "react": "^18.x || ^19.x"
             }
@@ -3825,6 +3821,7 @@
         "node_modules/@tabler/icons": {
             "version": "3.38.0",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/codecalm"
@@ -3915,7 +3912,6 @@
             "version": "10.4.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -4257,7 +4253,6 @@
         "node_modules/@types/react": {
             "version": "18.3.28",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -4915,7 +4910,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -5247,7 +5241,6 @@
         "node_modules/clsx": {
             "version": "2.1.1",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -6006,7 +5999,6 @@
             "version": "0.27.3",
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -7779,7 +7771,6 @@
             "version": "29.7.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -8857,7 +8848,6 @@
             "version": "24.1.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssstyle": "^4.0.1",
                 "data-urls": "^5.0.0",
@@ -10894,7 +10884,6 @@
         "node_modules/react": {
             "version": "18.3.1",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -10933,7 +10922,6 @@
         "node_modules/react-dom": {
             "version": "18.3.1",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -12272,7 +12260,6 @@
         "node_modules/tinyglobby/node_modules/picomatch": {
             "version": "4.0.3",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -12574,7 +12561,6 @@
             "version": "5.9.3",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -12884,7 +12870,6 @@
         "node_modules/vite": {
             "version": "7.3.1",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -12972,7 +12957,6 @@
         "node_modules/vite/node_modules/picomatch": {
             "version": "4.0.3",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },

--- a/setools/index.html
+++ b/setools/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SETools - Sepolicy Analyzer</title>
+    <link rel="stylesheet" href="main.css">
     <style>
         body, html, #root {
             height: 100%;
@@ -11,6 +12,21 @@
             padding: 0;
             overflow: hidden;
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        }
+
+        .react-tabs {
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            height: 100%;
+            min-height: 0;
+        }
+
+        .react-tabs__tab-panel--selected {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
         }
     </style>
 </head>

--- a/setools/main.tsx
+++ b/setools/main.tsx
@@ -154,7 +154,7 @@ function App({ file }: { file: File }) {
             </div>
 
             {/* Tabbed interface for different policy aspects */}
-            <Tabs style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+            <Tabs>
                 <TabList>
                     <Tab>Allow Rules ({rules.length})</Tab>
                     <Tab>Types ({filteredSymbols?.types.length || 0})</Tab>
@@ -167,8 +167,8 @@ function App({ file }: { file: File }) {
                 </TabList>
 
                 {/* Allow Rules Tab: uses AceEditor for large text display and search */}
-                <TabPanel style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-                    <div style={{ flex: 1, border: '1px solid #ccc', borderRadius: '4px' }}>
+                <TabPanel>
+                    <div style={{ flex: 1, border: '1px solid #ccc', borderRadius: '4px', minHeight: 0 }}>
                         <AceEditor
                             value={rules.join('\n')}
                             mode="lisp"
@@ -182,27 +182,27 @@ function App({ file }: { file: File }) {
                 </TabPanel>
 
                 {/* Symbol List Tabs */}
-                <TabPanel style={{ flex: 1, overflow: 'auto' }}>
+                <TabPanel style={{ overflow: 'auto' }}>
                     <SymbolList symbols={filteredSymbols?.types || []} />
                 </TabPanel>
-                <TabPanel style={{ flex: 1, overflow: 'auto' }}>
+                <TabPanel style={{ overflow: 'auto' }}>
                     <SymbolList symbols={filteredSymbols?.attributes || []} />
                 </TabPanel>
-                <TabPanel style={{ flex: 1, overflow: 'auto' }}>
+                <TabPanel style={{ overflow: 'auto' }}>
                     <SymbolList symbols={filteredSymbols?.roles || []} />
                 </TabPanel>
-                <TabPanel style={{ flex: 1, overflow: 'auto' }}>
+                <TabPanel style={{ overflow: 'auto' }}>
                     <SymbolList symbols={filteredSymbols?.bools || []} />
                 </TabPanel>
-                <TabPanel style={{ flex: 1, overflow: 'auto' }}>
+                <TabPanel style={{ overflow: 'auto' }}>
                     <SymbolList symbols={filteredSymbols?.users || []} />
                 </TabPanel>
-                <TabPanel style={{ flex: 1, overflow: 'auto' }}>
+                <TabPanel style={{ overflow: 'auto' }}>
                     <SymbolList symbols={filteredSymbols?.classes || []} />
                 </TabPanel>
 
                 {/* Metadata Summary Tab */}
-                <TabPanel style={{ flex: 1, overflow: 'auto' }}>
+                <TabPanel style={{ overflow: 'auto' }}>
                     <pre style={{ background: '#f5f5f5', padding: '15px' }}>{JSON.stringify(policyInfo.counts, null, 2)}</pre>
                 </TabPanel>
             </Tabs>


### PR DESCRIPTION
This change fixes two major UI issues in the SETools handler:
1. Navigation tabs were appearing as unstyled bullet points because the CSS was not being loaded in the HTML.
2. The AceEditor (text view) was collapsed because the tab panel containers were not properly configured to fill the available vertical space.

I've updated `index.html` to include the missing stylesheet and added global CSS rules to ensure `react-tabs` and its active panels use `display: flex` and `flex: 1`. I also cleaned up the inline styles in `main.tsx` to work harmoniously with these CSS changes.

Visual verification confirmed that tabs now look like tabs and the editor fills the screen. Integration tests passed successfully.

---
*PR created automatically by Jules for task [11421932443460901158](https://jules.google.com/task/11421932443460901158) started by @mauricelam*