### PR TITLE
Serve zipped dist directory on GitHub Pages

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -55,6 +55,7 @@ jobs:
       - run: npm test
       - run: npx playwright install --with-deps
       - run: npm run test:integration
+      - run: npm run zip-dist
       - name: Upload artifact
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "watch:workspaces": "npm pkg get name --ws | jq -c -r 'keys | .[]' | xargs -P 99 -I {} npm run watch --silent -w {}",
         "serve": "run-p --silent \"watch:workspaces\" start",
         "build": "npm run build:workspaces",
+        "zip-dist": "cd dist && zip -r dist.zip . -x dist.zip",
         "test": "npm run test --workspaces --if-present",
         "test:integration": "npm run build && node tests/integration/build.mjs && playwright test"
     },


### PR DESCRIPTION
Added a `zip-dist` script to `package.json` that packages the contents of the `dist` directory into `dist.zip` (excluding the zip file itself).
Updated `.github/workflows/node.js.yml` to execute this script before the `Upload artifact` step, ensuring that `dist.zip` is included in the deployed GitHub Pages.
Verified the script locally with dummy files and confirmed the CI workflow modification.
Cleaned up local testing debris as identified in the code review.

---
*PR created automatically by Jules for task [17726241031205485428](https://jules.google.com/task/17726241031205485428) started by @mauricelam*