### PR TITLE
Sandbox handler iframes and document internet requirements

### DIFF
--- a/cheerpj/README.md
+++ b/cheerpj/README.md
@@ -30,11 +30,11 @@ A handler that runs Java applications in the browser using CheerpJ technology.
 - Built with CheerpJ (Java to JavaScript compiler)
 - Runs Java applications entirely in the browser
 - Implements the standard `requestFile`/`respondFile` messaging protocol
-- No external dependencies or network requests for execution
+- **Internet Access**: Requires internet access to load the CheerpJ runtime from `https://cjrtnc.leaningtech.com`.
 
 ## Dependencies
 
-- **CheerpJ** - Java to JavaScript compiler and runtime
+- **CheerpJ** - Java to JavaScript compiler and runtime (loaded via CDN)
 
 ## Development
 

--- a/classyshark/README.md
+++ b/classyshark/README.md
@@ -30,12 +30,12 @@ A handler for Android APK files that provides analysis of package structure and 
 - Uses ClassyShark library for APK analysis
 - Implements the standard `requestFile`/`respondFile` messaging protocol
 - Processes files entirely in the browser
-- No external dependencies or network requests
+- **Internet Access**: Requires internet access to load the CheerpJ runtime from `https://cjrtnc.leaningtech.com`.
 
 ## Dependencies
 
 - **ClassyShark** - Java APK analysis library
-- **CheerpJ** - Java to JavaScript compiler
+- **CheerpJ** - Java to JavaScript compiler (loaded via CDN)
 
 ## Development
 

--- a/cyberchef/main.tsx
+++ b/cyberchef/main.tsx
@@ -16,6 +16,7 @@ async function handleFile(file: File) {
     const iframe = document.createElement('iframe');
     iframe.id = 'cyberchef';
     iframe.src = `CyberChef/CyberChef_v10.19.4.html`;
+    iframe.sandbox.add('allow-scripts', 'allow-same-origin', 'allow-downloads', 'allow-forms');
 
     iframe.onload = async () => {
         try {

--- a/main/IframeManager.tsx
+++ b/main/IframeManager.tsx
@@ -107,6 +107,7 @@ export function IframeManager({ activeHandler, files }: IframeManagerProps) {
                         src={frame.handler}
                         style={{ display: isActive ? 'block' : 'none' }}
                         title={frame.file.name}
+                        sandbox="allow-scripts allow-same-origin allow-forms"
                     />
                 );
             })}

--- a/tests/integration/driver.ts
+++ b/tests/integration/driver.ts
@@ -3,6 +3,7 @@ const params = new URLSearchParams(window.location.search);
 const handler = params.get('handler');
 const iframeEl = document.getElementById('file-handler-iframe') as HTMLIFrameElement;
 if (handler) {
+    iframeEl.sandbox.add('allow-scripts', 'allow-same-origin', 'allow-forms');
     iframeEl.src = `/filetool/${handler}/index.html`;
 }
 


### PR DESCRIPTION
I have applied the `sandbox` attribute to all handler iframes to improve security. Most handlers now run with `allow-scripts allow-same-origin allow-forms`. CyberChef has been granted an additional `allow-downloads` permission to preserve its functionality. I've also updated the documentation for the CheerpJ and ClassyShark handlers to explain their need for internet access (loading the runtime from a CDN). Integration tests have been updated and verified to ensure that these security restrictions do not break existing features.

---
*PR created automatically by Jules for task [2441744765344619664](https://jules.google.com/task/2441744765344619664) started by @mauricelam*