### PR TITLE
Enhance hex viewer marker management and UI

### DIFF
--- a/hex_viewer/hex.tsx
+++ b/hex_viewer/hex.tsx
@@ -7,6 +7,7 @@ export interface RenderState {
     selectionStart: number | null;
     selectionEnd: number | null;
     markers: Marker[];
+    previewMarker?: Marker | null;
     onMouseDown: (index: number) => void;
     onMouseEnter: (index: number) => void;
     onMouseLeave: () => void;
@@ -59,8 +60,15 @@ export function renderAscii(line: number, buffer: Uint8Array, state: RenderState
                         } else {
                             classList.push("marked_length");
                         }
+                        if (marker.start + marker.length > buffer.length) {
+                            classList.push("marked_overflow");
+                        }
                     }
                 }
+            }
+
+            if (state.previewMarker && i >= state.previewMarker.start && i < state.previewMarker.start + state.previewMarker.length) {
+                classList.push("preview_marked");
             }
 
             yield (
@@ -116,8 +124,15 @@ export function renderHex(line: number, buffer: Uint8Array, state: RenderState):
                         } else {
                             classList.push("marked_length");
                         }
+                        if (marker.start + marker.length > buffer.length) {
+                            classList.push("marked_overflow");
+                        }
                     }
                 }
+            }
+
+            if (state.previewMarker && i >= state.previewMarker.start && i < state.previewMarker.start + state.previewMarker.length) {
+                classList.push("preview_marked");
             }
 
             const space = i == line * 16 ? "" : " "

--- a/hex_viewer/index.html
+++ b/hex_viewer/index.html
@@ -55,6 +55,15 @@
             text-decoration-color: #5bc0de;
         }
 
+        .marked_overflow {
+            text-decoration-color: #ff0000 !important;
+        }
+
+        .preview_marked {
+            text-decoration: underline dashed #aaa !important;
+            text-decoration-thickness: 2px;
+        }
+
         #inspector {
             width: 300px;
             background-color: #1e1e1e;
@@ -112,6 +121,31 @@
             border: 1px solid #3c3c3c;
             padding: 2px;
             font-size: 12px;
+        }
+
+        .icon-button {
+            padding: 2px 4px;
+            margin-left: 4px;
+            font-size: 10px;
+            line-height: 1;
+            min-width: 18px;
+            text-align: center;
+        }
+
+        .marker-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            font-size: 12px;
+            color: #ddd;
+        }
+
+        .marker-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 4px 0;
+            border-bottom: 1px solid #2d2d2d;
         }
     </style>
 </head>

--- a/hex_viewer/main.tsx
+++ b/hex_viewer/main.tsx
@@ -28,9 +28,8 @@ async function handleFile(file: File) {
     OUTPUT.render(<HexViewer buffer={buf} />)
 }
 
-function DataInspector({ buffer, index, selection, onAddMarker }: { buffer: Uint8Array, index: number | null, selection: [number, number] | null, onAddMarker: (format: string, length: number, type?: 'data' | 'length', headerLength?: number) => void }) {
-    const [littleEndian, setLittleEndian] = useState(true);
-    const [format, setFormat] = useState('uint32');
+function DataInspector({ buffer, index, selection, markers, onAddMarker, onRemoveMarker, setPreviewMarker }: { buffer: Uint8Array, index: number | null, selection: [number, number] | null, markers: Marker[], onAddMarker: (format: string, length: number, type?: 'data' | 'length', headerLength?: number) => void, onRemoveMarker: (index: number) => void, setPreviewMarker: (marker: Marker | null) => void }) {
+    const [littleEndian, setLittleEndian] = useState(false);
 
     const targetIndex = index !== null ? index : (selection ? selection[0] : null);
 
@@ -44,22 +43,23 @@ function DataInspector({ buffer, index, selection, onAddMarker }: { buffer: Uint
     }
 
     const view = utils.getDataView(buffer);
-    const rows: { label: string, value: string, numericValue?: number | bigint }[] = [];
+    const rows: { label: string, value: string, numericValue?: number | bigint, size: number }[] = [];
 
     const safeRead = (label: string, size: number, fn: () => number | bigint) => {
         try {
             if (targetIndex + size > buffer.length) {
-                rows.push({ label, value: "N/A" });
+                rows.push({ label, value: "N/A", size });
                 return;
             }
             const val = fn();
             rows.push({
                 label,
                 value: typeof val === 'bigint' ? val.toString() : val.toLocaleString(),
-                numericValue: val
+                numericValue: val,
+                size
             });
         } catch (e) {
-            rows.push({ label, value: "Error" });
+            rows.push({ label, value: "Error", size });
         }
     };
 
@@ -78,10 +78,9 @@ function DataInspector({ buffer, index, selection, onAddMarker }: { buffer: Uint
     rows.push({
         label: "Varint",
         value: varint.value.toString() + ` (${varint.length} bytes)`,
-        numericValue: varint.value
+        numericValue: varint.value,
+        size: varint.length
     });
-
-    const currentFormatValue = rows.find(r => r.label.toLowerCase() === format.toLowerCase())?.numericValue;
 
     return (
         <div id="inspector">
@@ -104,46 +103,50 @@ function DataInspector({ buffer, index, selection, onAddMarker }: { buffer: Uint
             {rows.map(r => (
                 <div key={r.label} className="inspector-row">
                     <span className="inspector-label">{r.label}</span>
-                    <span className="inspector-value">{r.value}</span>
+                    <span className="inspector-value">
+                        {r.value}
+                        <button
+                            className="icon-button"
+                            title="Add Marker"
+                            onMouseEnter={() => setPreviewMarker({ start: targetIndex, length: r.size, format: r.label + (littleEndian ? 'le' : 'be') })}
+                            onMouseLeave={() => setPreviewMarker(null)}
+                            onClick={() => onAddMarker(r.label + (littleEndian ? 'le' : 'be'), r.size)}
+                        >
+                            M
+                        </button>
+                        <button
+                            className="icon-button"
+                            title="Treat as Length"
+                            disabled={r.numericValue === undefined || (typeof r.numericValue === 'number' && r.numericValue < 0) || (typeof r.numericValue === 'bigint' && r.numericValue < 0n)}
+                            onMouseEnter={() => {
+                                if (r.numericValue !== undefined) {
+                                    const dataLength = Number(r.numericValue);
+                                    setPreviewMarker({ start: targetIndex, length: r.size + dataLength, format: 'length', type: 'length', headerLength: r.size });
+                                }
+                            }}
+                            onMouseLeave={() => setPreviewMarker(null)}
+                            onClick={() => {
+                                if (r.numericValue !== undefined) {
+                                    const dataLength = Number(r.numericValue);
+                                    onAddMarker('length', r.size + dataLength, 'length', r.size);
+                                }
+                            }}
+                        >
+                            L
+                        </button>
+                    </span>
                 </div>
             ))}
 
             <h3>Markers</h3>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                <select value={format} onChange={(e) => setFormat(e.target.value)}>
-                    <option value="uint8">Uint8</option>
-                    <option value="uint16">Uint16</option>
-                    <option value="uint32">Uint32</option>
-                    <option value="uint64">Uint64</option>
-                    <option value="varint">Varint</option>
-                </select>
-                <button onClick={() => {
-                    let length = 0;
-                    if (format === 'uint8') length = 1;
-                    else if (format === 'uint16') length = 2;
-                    else if (format === 'uint32') length = 4;
-                    else if (format === 'uint64') length = 8;
-                    else if (format === 'varint') length = varint.length;
-                    onAddMarker(format + (littleEndian ? 'le' : 'be'), length);
-                }}>Add Marker at 0x{targetIndex.toString(16).toUpperCase()}</button>
-
-                <button
-                    disabled={currentFormatValue === undefined}
-                    onClick={() => {
-                        let headerLength = 0;
-                        if (format === 'uint8') headerLength = 1;
-                        else if (format === 'uint16') headerLength = 2;
-                        else if (format === 'uint32') headerLength = 4;
-                        else if (format === 'uint64') headerLength = 8;
-                        else if (format === 'varint') headerLength = varint.length;
-
-                        const dataLength = Number(currentFormatValue);
-                        onAddMarker('length', headerLength + dataLength, 'length', headerLength);
-                    }}
-                >
-                    Treat as Length
-                </button>
-            </div>
+            <ul className="marker-list">
+                {markers.map((m, i) => (
+                    <li key={i} className="marker-item">
+                        <span>0x{m.start.toString(16).toUpperCase()}: {m.format} ({m.length})</span>
+                        <button className="icon-button" onClick={() => onRemoveMarker(i)}>X</button>
+                    </li>
+                ))}
+            </ul>
         </div>
     )
 }
@@ -153,7 +156,10 @@ function HexViewer({ buffer }: { buffer: Uint8Array }) {
     const [selectionStart, setSelectionStart] = useState<number | null>(null);
     const [selectionEnd, setSelectionEnd] = useState<number | null>(null);
     const [markers, setMarkers] = useState<Marker[]>([]);
+    const [previewMarker, setPreviewMarker] = useState<Marker | null>(null);
     const [isSelecting, setIsSelecting] = useState(false);
+
+    const selection: [number, number] | null = selectionStart !== null && selectionEnd !== null ? [Math.min(selectionStart, selectionEnd), Math.max(selectionStart, selectionEnd)] : null;
 
     const onMouseDown = useCallback((index: number) => {
         setSelectionStart(index);
@@ -173,11 +179,15 @@ function HexViewer({ buffer }: { buffer: Uint8Array }) {
     }, []);
 
     const onAddMarker = useCallback((format: string, length: number, type: 'data' | 'length' = 'data', headerLength?: number) => {
-        const start = selectionStart !== null ? selectionStart : hoverIndex;
+        const start = selection !== null ? selection[0] : hoverIndex;
         if (start !== null) {
             setMarkers([...markers, { start, length, format, type, headerLength }]);
         }
-    }, [markers, selectionStart, hoverIndex]);
+    }, [markers, selection, hoverIndex]);
+
+    const onRemoveMarker = useCallback((index: number) => {
+        setMarkers(markers.filter((_, i) => i !== index));
+    }, [markers]);
 
     useEffect(() => {
         const onMouseUp = () => setIsSelecting(false);
@@ -186,7 +196,6 @@ function HexViewer({ buffer }: { buffer: Uint8Array }) {
     }, []);
 
     const lineCount = Math.ceil(buffer.length / 16)
-    const selection: [number, number] | null = selectionStart !== null && selectionEnd !== null ? [Math.min(selectionStart, selectionEnd), Math.max(selectionStart, selectionEnd)] : null;
 
     return (
         <div style={{ display: 'flex', height: '100%' }}>
@@ -196,12 +205,12 @@ function HexViewer({ buffer }: { buffer: Uint8Array }) {
                     render={(i) => <div key={i}>{offset(i, buffer)}</div>} />
                 <Column id="hex" lineCount={lineCount}
                     header="00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F"
-                    render={(i) => <div key={i}>{renderHex(i, buffer, { hoverIndex, selectionStart, selectionEnd, markers, onMouseDown, onMouseEnter, onMouseLeave })}</div>} />
+                    render={(i) => <div key={i}>{renderHex(i, buffer, { hoverIndex, selectionStart, selectionEnd, markers, previewMarker, onMouseDown, onMouseEnter, onMouseLeave })}</div>} />
                 <Column id="ascii" lineCount={lineCount}
                     header=" "
-                    render={(i) => <div key={i}>{renderAscii(i, buffer, { hoverIndex, selectionStart, selectionEnd, markers, onMouseDown, onMouseEnter, onMouseLeave })}</div>} />
+                    render={(i) => <div key={i}>{renderAscii(i, buffer, { hoverIndex, selectionStart, selectionEnd, markers, previewMarker, onMouseDown, onMouseEnter, onMouseLeave })}</div>} />
             </div>
-            <DataInspector buffer={buffer} index={hoverIndex} selection={selection} onAddMarker={onAddMarker} />
+            <DataInspector buffer={buffer} index={hoverIndex} selection={selection} markers={markers} onAddMarker={onAddMarker} onRemoveMarker={onRemoveMarker} setPreviewMarker={setPreviewMarker} />
         </div>
     )
 }


### PR DESCRIPTION
This PR enhances the hex viewer's marker system and data inspector UI. 

Key changes:
1. **Marker Removal**: Added a 'Markers' section in the inspector that lists all current markers with an 'X' button to delete them.
2. **Overflow Highlighting**: Implemented CSS and logic to color length markers in red if they extend beyond the file's end.
3. **Big-Endian Default**: Updated the initial state of the data inspector to default to Big-Endian.
4. **Improved Marker Addition**: Replaced the previous dropdown/button UI with small 'M' (Add Marker) and 'L' (Treat as Length) buttons next to each format row in the inspector.
5. **Hover Previews**: Added interactive previews that show a dashed underline in the hex/ascii views when hovering over addition buttons.
6. **RTL Selection Fix**: Corrected the logic for determining a marker's start index to handle backwards drags (right-to-left).

Verified with existing unit tests and new visual verification scripts.

---
*PR created automatically by Jules for task [1747728884229403926](https://jules.google.com/task/1747728884229403926) started by @mauricelam*