### PR TITLE
Persist selected handlers across file navigation and pin "Other" handlers

### DIFF
--- a/main/App.tsx
+++ b/main/App.tsx
@@ -17,6 +17,7 @@ export function App() {
     const [selected, setSelected] = useState(0)
     const [files, setFiles] = useState<File[]>([])
     const [activeHandlers, setActiveHandlers] = useState<(HandlerConfig | undefined)[]>([]);
+    const [pinnedHandlers, setPinnedHandlers] = useState<string[][]>([]);
     const [pastedText, setPastedText] = useState<string | null>(null);
 
     // Global paste handler
@@ -52,6 +53,7 @@ export function App() {
     const handleAddFiles = (newFiles: File[]) => {
         setFiles(cur => [...cur, ...newFiles]);
         setActiveHandlers(cur => [...cur, ...Array(newFiles.length)])
+        setPinnedHandlers(cur => [...cur, ...newFiles.map(() => [])]);
     }
 
     const removeFile = (index: number) => {
@@ -65,7 +67,12 @@ export function App() {
             const newHandlers = [...cur];
             newHandlers.splice(index, 1);
             return newHandlers;
-        })
+        });
+        setPinnedHandlers(cur => {
+            const newPinned = [...cur];
+            newPinned.splice(index, 1);
+            return newPinned;
+        });
     };
 
     useEffect(() => {
@@ -130,6 +137,16 @@ export function App() {
                                     });
                                 }}
                                 initialActiveHandler={activeHandlers[selected]}
+                                pinnedHandlers={pinnedHandlers[selected] || []}
+                                onAddPinnedHandler={(handlerId: string) => {
+                                    setPinnedHandlers(cur => {
+                                        const updatedPinned = [...cur];
+                                        if (!updatedPinned[selected].includes(handlerId)) {
+                                            updatedPinned[selected] = [...updatedPinned[selected], handlerId];
+                                        }
+                                        return updatedPinned;
+                                    });
+                                }}
                             />
                         }
                     </div>
@@ -144,13 +161,15 @@ interface LoadFileItemProps {
     file: File;
     openHandler: (handlerConfig: HandlerConfig) => void;
     initialActiveHandler?: HandlerConfig;
+    pinnedHandlers: string[];
+    onAddPinnedHandler: (handlerId: string) => void;
 }
 
-function LoadFileItem({ file, openHandler, initialActiveHandler }: LoadFileItemProps): ReactNode {
+function LoadFileItem({ file, openHandler, initialActiveHandler, pinnedHandlers, onAddPinnedHandler }: LoadFileItemProps): ReactNode {
     const [handlers, setHandlers] = useState<any[]>([]);
     const [mime, setMime] = useState("");
     const [description, setDescription] = useState("Loading...");
-    const [activeHandler, setActiveHandler] = useState<HandlerConfig | undefined>(initialActiveHandler) ?? getDefaultHandler(mime, file.name);
+    const [activeHandler, setActiveHandler] = useState<HandlerConfig | undefined>(initialActiveHandler);
 
     const magicPromise = WASMagic.create({
         flags: WASMagicFlags.NONE,
@@ -177,13 +196,15 @@ function LoadFileItem({ file, openHandler, initialActiveHandler }: LoadFileItemP
                 window.history.pushState({ fileName: file.name }, file.name);
             }
 
-            const defaultHandlerId = getDefaultHandler(mime, file.name);
-            if (defaultHandlerId) {
-                const defaultHandlerConfig = HANDLERS.find(h => h.handler === defaultHandlerId);
-                if (defaultHandlerConfig) {
-                    const isMatch = defaultHandlerConfig.mimetypes.some(m => matchMimetype(m, mime, file.name));
-                    if (isMatch) {
-                        setTimeout(() => openHandler({ handler: defaultHandlerConfig.handler, file, magicMime: mime }), 0);
+            if (!initialActiveHandler) {
+                const defaultHandlerId = getDefaultHandler(mime, file.name);
+                if (defaultHandlerId) {
+                    const defaultHandlerConfig = HANDLERS.find(h => h.handler === defaultHandlerId);
+                    if (defaultHandlerConfig) {
+                        const isMatch = defaultHandlerConfig.mimetypes.some(m => matchMimetype(m, mime, file.name));
+                        if (isMatch) {
+                            setTimeout(() => openHandler({ handler: defaultHandlerConfig.handler, file, magicMime: mime }), 0);
+                        }
                     }
                 }
             }
@@ -194,6 +215,7 @@ function LoadFileItem({ file, openHandler, initialActiveHandler }: LoadFileItemP
     const onOpenFile = (handlerConfig: HandlerConfig) => {
         openHandler(handlerConfig);
         setActiveHandler(handlerConfig);
+        onAddPinnedHandler(handlerConfig.handler);
     }
 
     return (
@@ -206,6 +228,7 @@ function LoadFileItem({ file, openHandler, initialActiveHandler }: LoadFileItemP
             matchedHandlers={handlers}
             allHandlers={HANDLERS}
             initialActiveHandler={activeHandler?.handler}
+            pinnedHandlers={pinnedHandlers}
             onOpenHandler={onOpenFile}
         />
     )

--- a/main/fileitem.tsx
+++ b/main/fileitem.tsx
@@ -30,12 +30,13 @@ interface FileItemProps {
     description: string;
     matchedHandlers: HandlerDefinition[];
     allHandlers: HandlerDefinition[];
+    pinnedHandlers: string[];
     onOpenHandler: (handlerConfig: HandlerConfig) => void;
     initialActiveHandler?: string;
 }
 
 export function FileItem(
-    { file, name, mimetype, description, matchedHandlers, allHandlers, onOpenHandler, initialActiveHandler }: FileItemProps
+    { file, name, mimetype, description, matchedHandlers, allHandlers, pinnedHandlers, onOpenHandler, initialActiveHandler }: FileItemProps
 ) {
     const [isOtherHandlersDialogOpen, setOtherHandlersDialogOpen] = useState(false);
     const [otherHandlersFilter, setOtherHandlersFilter] = useState('');
@@ -78,10 +79,10 @@ export function FileItem(
 
     // Set initial active handler if provided
     useEffect(() => {
-        if (activeHandlerId === null && initialActiveHandler) {
+        if (initialActiveHandler) {
             setActiveHandlerId(initialActiveHandler);
         }
-    }, [activeHandlerId, initialActiveHandler]);
+    }, [initialActiveHandler]);
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
@@ -218,8 +219,11 @@ export function FileItem(
                 <div className="buttonBar" style={{ display: 'flex', alignItems: 'center', marginTop: '5px' }}>
                     <label style={labelStyle}>Open with</label>
                     <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
-                        {matchedHandlers
-                            .filter(handler => !isUniversal(handler))
+                        {[...matchedHandlers.filter(h => !isUniversal(h)),
+                        ...allHandlers.filter(h => pinnedHandlers.includes(h.handler) || h.handler === activeHandlerId)]
+                            .filter((handler, index, self) =>
+                                index === self.findIndex((t) => t.handler === handler.handler)
+                            )
                             .sort((a, b) => {
                                 // Sort active handler to the front
                                 if (a.handler === activeHandlerId) return -1;

--- a/tests/integration/other-handler-persistence.spec.ts
+++ b/tests/integration/other-handler-persistence.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+test('other handler should persist in button bar and when switching files', async ({ page }) => {
+    await page.goto('/filetool/');
+
+    // Wait for the drop target to be ready
+    const dropTarget = page.locator('#droptarget');
+    await expect(dropTarget).toBeVisible();
+
+    // 1. Open first file
+    await page.evaluate(() => {
+        const file = new File(['file 1 content'], 'file1.bin', { type: 'application/octet-stream' });
+        window.dispatchEvent(new CustomEvent('openFiles', { detail: [file] }));
+    });
+    await expect(page.locator('.filename')).toHaveText('file1.bin');
+
+    // 2. Select Hex from "Other"
+    await page.getByTitle('Show all handlers').click();
+    const searchBox = page.getByPlaceholder('Filter by name, mime, or extension');
+    await searchBox.fill('Hex');
+    await searchBox.press('Enter');
+
+    // Verify Hex is active (it's a universal handler, so it should be visible now)
+    const hexButton = page.locator('.buttonBar button', { hasText: 'Hex' });
+    await expect(hexButton).toBeVisible();
+    // It should have the active style (e6f3ff background)
+    await expect(hexButton).toHaveCSS('background-color', 'rgb(230, 243, 255)');
+
+    // 3. Select CyberChef from "Other"
+    await page.getByTitle('Show all handlers').click();
+    await searchBox.fill('CyberChef');
+    await searchBox.press('Enter');
+
+    // Verify both Hex and CyberChef are in the button bar
+    const cyberChefButton = page.locator('.buttonBar button', { hasText: 'CyberChef' });
+    await expect(cyberChefButton).toBeVisible();
+    await expect(hexButton).toBeVisible();
+    await expect(cyberChefButton).toHaveCSS('background-color', 'rgb(230, 243, 255)');
+
+    // 4. Open second file
+    await page.evaluate(() => {
+        const file = new File(['file 2 content'], 'file2.txt', { type: 'text/plain' });
+        window.dispatchEvent(new CustomEvent('openFiles', { detail: [file] }));
+    });
+    await expect(page.locator('.filename')).toHaveText('file2.txt');
+    // For a txt file, Text Viewer should be default/matched, CyberChef/Hex should NOT be there yet
+    await expect(page.locator('.buttonBar button', { hasText: 'CyberChef' })).not.toBeVisible();
+
+    // 5. Switch back to file1.bin
+    await page.getByText('file1.bin').click();
+    await expect(page.locator('.filename')).toHaveText('file1.bin');
+
+    // Verify CyberChef is still active and both buttons are still there
+    await expect(page.locator('.buttonBar button', { hasText: 'CyberChef' })).toBeVisible();
+    await expect(page.locator('.buttonBar button', { hasText: 'Hex' })).toBeVisible();
+    await expect(page.locator('.buttonBar button', { hasText: 'CyberChef' })).toHaveCSS('background-color', 'rgb(230, 243, 255)');
+});


### PR DESCRIPTION
This PR addresses the issue where selecting a handler from the "Other" menu would not persist when navigating between files, and the selection was not visually indicated in the main button bar.

Key changes:
- Centralized handler state in `App.tsx`.
- Introduced `pinnedHandlers` state to track handlers selected from the "Other" dialog.
- Refactored components to use props instead of redundant local state for the active handler.
- Added a new integration test for persistence and UI visibility.

---
*PR created automatically by Jules for task [17399817085111248936](https://jules.google.com/task/17399817085111248936) started by @mauricelam*