### PR TITLE
Make hex viewer sidebar collapsible on small screens

### DIFF
--- a/hex_viewer/index.html
+++ b/hex_viewer/index.html
@@ -381,6 +381,30 @@
         .selection-actions button svg {
             flex-shrink: 0;
         }
+
+        .sidebar-toggle {
+            position: absolute;
+            top: 60px;
+            width: 20px;
+            height: 40px;
+            background-color: #252526;
+            border: 1px solid #333;
+            border-right: none;
+            color: #888;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0;
+            z-index: 100;
+            border-radius: 4px 0 0 4px;
+            transition: right 0.2s ease, color 0.2s;
+        }
+
+        .sidebar-toggle:hover {
+            background-color: #2d2d2d;
+            color: #fff;
+        }
     </style>
 </head>
 

--- a/hex_viewer/main.tsx
+++ b/hex_viewer/main.tsx
@@ -33,7 +33,9 @@ const ICONS = {
     binwalk: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M8 3v18"></path><path d="M8 3h4a4 4 0 0 1 0 8H8"></path><path d="M8 11h4a4 4 0 0 1 0 8H8"></path><path d="M2 9h3c1 0 1.5 1 3 1"></path><path d="M2 15h3c1 0 1.5-1 3-1"></path><circle cx="2" cy="9" r="1" fill="currentColor"></circle><circle cx="2" cy="15" r="1" fill="currentColor"></circle></svg>,
     copy: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>,
     open: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>,
-    add: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+    add: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>,
+    chevronLeft: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>,
+    chevronRight: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
 };
 
 async function handleFile(file: File) {
@@ -810,6 +812,7 @@ function HexViewer({ buffer }: { buffer: Uint8Array }) {
 
     const [sidebarWidth, setSidebarWidth] = useState(300);
     const [isResizing, setIsResizing] = useState(false);
+    const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(window.innerWidth < 800);
 
     const startResizing = useCallback(() => {
         setIsResizing(true);
@@ -829,6 +832,16 @@ function HexViewer({ buffer }: { buffer: Uint8Array }) {
     }, [isResizing]);
 
     useEffect(() => {
+        const handleResize = () => {
+            if (window.innerWidth < 800) {
+                setIsSidebarCollapsed(true);
+            }
+        };
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    useEffect(() => {
         window.addEventListener('mousemove', resize);
         window.addEventListener('mouseup', stopResizing);
         return () => {
@@ -838,7 +851,7 @@ function HexViewer({ buffer }: { buffer: Uint8Array }) {
     }, [resize, stopResizing]);
 
     return (
-        <div style={{ display: 'flex', height: '100%', userSelect: isResizing ? 'none' : 'auto' }}>
+        <div style={{ display: 'flex', height: '100%', userSelect: isResizing ? 'none' : 'auto', position: 'relative' }}>
             <div id="hexviewer" style={{ flex: 1, overflowY: 'auto' }} onScroll={onScroll}>
                 <Column id="offset" lineCount={lineCount} scrollTop={scrollTop}
                     header="Offset"
@@ -850,8 +863,18 @@ function HexViewer({ buffer }: { buffer: Uint8Array }) {
                     header=" "
                     render={(i) => <div key={i}>{renderAscii(i, buffer, { hoverIndex, selectionStart, selectionEnd, markers, previewMarker, searchResultOffsets, currentMatchOffset: currentMatchIndex !== null ? searchResults[currentMatchIndex] : null, matchLength, onMouseDown, onMouseEnter, onMouseLeave })}</div>} />
             </div>
-            <div id="resize-handle" onMouseDown={startResizing} />
-            <div id="inspector-container" style={{ width: sidebarWidth, display: 'flex' }}>
+            {!isSidebarCollapsed && <div id="resize-handle" onMouseDown={startResizing} />}
+            <button
+                className="sidebar-toggle"
+                onClick={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
+                style={{
+                    right: isSidebarCollapsed ? 0 : sidebarWidth
+                }}
+                title={isSidebarCollapsed ? "Expand Sidebar" : "Collapse Sidebar"}
+            >
+                {isSidebarCollapsed ? ICONS.chevronLeft : ICONS.chevronRight}
+            </button>
+            <div id="inspector-container" style={{ width: sidebarWidth, display: isSidebarCollapsed ? 'none' : 'flex' }}>
                 <DataInspector
                     buffer={buffer}
                     index={hoverIndex}

--- a/tests/integration/hex_viewer.spec.ts
+++ b/tests/integration/hex_viewer.spec.ts
@@ -51,18 +51,31 @@ test.describe('Hex Viewer', () => {
     await expect(shaValue).not.toHaveText('');
 
     // 4. Resize
-    const handle = page.locator('#resize-handle');
     const initialBox = await page.locator('#inspector-container').boundingBox();
+    const handle = page.locator('#resize-handle');
 
     const handleBox = await handle.boundingBox();
     if (handleBox && initialBox) {
-        await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
+        // Click near the top of the handle to avoid the toggle button (which is centered)
+        const startX = handleBox.x + handleBox.width / 2;
+        const startY = 10;
+        await page.mouse.move(startX, startY);
         await page.mouse.down();
-        await page.mouse.move(handleBox.x - 50, handleBox.y + handleBox.height / 2);
+        // Move mouse to the left to INCREASE sidebar width (since sidebar is on the right)
+        await page.mouse.move(startX - 100, startY, { steps: 10 });
         await page.mouse.up();
 
         const finalBox = await page.locator('#inspector-container').boundingBox();
         expect(finalBox?.width).toBeGreaterThan(initialBox.width);
     }
+
+    // 5. Collapse/Expand Sidebar
+    await page.click('.sidebar-toggle');
+    await expect(page.locator('#inspector-container')).not.toBeVisible();
+    await expect(page.locator('#resize-handle')).not.toBeVisible();
+
+    await page.click('.sidebar-toggle');
+    await expect(page.locator('#inspector-container')).toBeVisible();
+    await expect(page.locator('#resize-handle')).toBeVisible();
   });
 });


### PR DESCRIPTION
This PR introduces a collapsible sidebar in the hex viewer to improve usability on smaller screens. Key features include:
- **Auto-collapse:** The sidebar automatically hides when the window width drops below 800px.
- **Manual toggle:** A persistent handle-like button on the right edge allows users to manually expand or collapse the sidebar.
- **Responsive layout:** The hex grid and ASCII columns expand to fill the available space when the sidebar is collapsed.
- **Fixed tests:** The integration test for resizing the sidebar was updated to avoid the new toggle button, ensuring continued test reliability.

---
*PR created automatically by Jules for task [796040595166439316](https://jules.google.com/task/796040595166439316) started by @mauricelam*