### PR TITLE
Cleanup Cloudflare Pages preview deployments on PR close

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,13 +11,12 @@ on:
     branches: ["main"]
     types: [opened, synchronize, reopened, closed]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-build
+      cancel-in-progress: true
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       contents: read
@@ -172,7 +171,14 @@ jobs:
   cleanup:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-cleanup
     steps:
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22.x
+
       - name: Cleanup Cloudflare Pages deployments
         if: secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != ''
         run: |
@@ -180,8 +186,8 @@ jobs:
           DEPLOYMENTS=$(npx wrangler pages deployment list --project-name=filetool --environment=preview --json)
 
           # Use jq to filter deployments for the specific branch and get their IDs
-          # We check if deployment_trigger.metadata.branch matches the PR's head branch
-          IDS=$(echo "$DEPLOYMENTS" | jq -r ".[] | select(.deployment_trigger.metadata.branch == env.BRANCH_NAME) | .id")
+          # We check if branch matches the PR's head branch in common metadata locations
+          IDS=$(echo "$DEPLOYMENTS" | jq -r ".[] | select(.deployment_trigger.metadata.branch == env.BRANCH_NAME or .meta.branch == env.BRANCH_NAME) | .id")
 
           if [ -z "$IDS" ]; then
             echo "No deployments found for branch: $BRANCH_NAME"


### PR DESCRIPTION
This change updates the GitHub Actions CI workflow to automatically delete Cloudflare Pages preview deployments when a pull request is closed or merged. This helps manage the number of active deployments and keeps the Cloudflare project clean.

Key changes:
- Updated `.github/workflows/node.js.yml` to trigger on `pull_request` `closed` events.
- Added a conditional check to the `build` job to ensure it doesn't run during a closure event.
- Added a new `cleanup` job that:
    - Lists preview deployments for the project.
    - Filters them by the PR's head branch name.
    - Deletes each matching deployment using the `wrangler` CLI.
- Improved script security by using environment variables for branch names to prevent potential shell injection.

---
*PR created automatically by Jules for task [7596696725498351313](https://jules.google.com/task/7596696725498351313) started by @mauricelam*