### PR TITLE
Optimize Cloudflare Pages deployments and PR comments

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,13 +9,14 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
   build:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-build
+      cancel-in-progress: true
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       contents: read
@@ -115,6 +116,13 @@ jobs:
           / /filetool/ 302
           EOF
 
+      - name: Clean up previous deployments for this branch
+        if: github.event_name == 'pull_request' && env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          DEPLOYMENTS=$(npx wrangler pages deployment list --project-name=filetool --json)
+          echo "$DEPLOYMENTS" | jq -r --arg branch "$BRANCH" '.[] | select(.deployment_trigger.metadata.branch == $branch or .meta.branch == $branch) | .id' | xargs -I {} npx wrangler pages deployment delete {} --project-name=filetool --force || true
+
       - name: Deploy to Cloudflare Pages
         id: deploy
         if: github.event_name == 'pull_request' && env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
@@ -129,12 +137,30 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.createComment({
+            const commentPrefix = '🚀 Cloudflare Pages preview is ready!';
+            const commentBody = `${commentPrefix} \n\nView it at: ${'${{ steps.deploy.outputs.deployment-url }}'}/filetool/`;
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🚀 Cloudflare Pages preview is ready! \n\nView it at: ${'${{ steps.deploy.outputs.deployment-url }}'}/filetool/`
-            })
+              per_page: 100
+            });
+            const existingComment = comments.find(c => c.user.login === 'github-actions[bot]' && c.body.startsWith(commentPrefix));
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: commentBody
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              });
+            }
 
       - name: Comment on PR if secrets are missing
         if: github.event_name == 'pull_request' && (env.CLOUDFLARE_API_TOKEN == '' || env.CLOUDFLARE_ACCOUNT_ID == '') && github.event.action == 'opened'
@@ -158,3 +184,17 @@ jobs:
         if: github.ref == 'refs/heads/main'
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+
+  cleanup:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - name: Delete deployments for the closed PR branch
+        if: env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          DEPLOYMENTS=$(npx wrangler pages deployment list --project-name=filetool --json)
+          echo "$DEPLOYMENTS" | jq -r --arg branch "$BRANCH" '.[] | select(.deployment_trigger.metadata.branch == $branch or .meta.branch == $branch) | .id' | xargs -I {} npx wrangler pages deployment delete {} --project-name=filetool --force || true


### PR DESCRIPTION
This PR optimizes the Cloudflare Pages preview deployment process in the GitHub workflow.

Key changes:
1. **Deployment Cleanup**: A new `cleanup` job is added that triggers when a pull request is closed, deleting all associated Cloudflare Pages deployments for that branch.
2. **Single Deployment Record**: Within the `build` job, a step is added to delete any existing deployments for the current branch *before* creating a new one. This ensures that Cloudflare only keeps the most recent preview for each branch.
3. **Single PR Comment**: The workflow now searches for an existing deployment comment from the GitHub Actions bot. If found, it updates that comment with the new deployment URL instead of posting a new one for every commit.
4. **Improved Concurrency**: The `concurrency` group is moved to the `build` job level. This prevents a pending cleanup job from being canceled by a new build, ensuring that deployments are always cleaned up when a PR is closed.
5. **Robust Tooling**: Updated `jq` commands to use the `-r` (raw) flag to correctly pass IDs to the `wrangler` CLI and increased the comment search limit to 100 to handle busy PRs.

---
*PR created automatically by Jules for task [3632292185393970224](https://jules.google.com/task/3632292185393970224) started by @mauricelam*