### PR TITLE
Consolidate Cloudflare Pages deployments and comments

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -116,6 +116,27 @@ jobs:
           / /filetool/ 302
           EOF
 
+      - name: Delete previous deployments
+        if: github.event_name == 'pull_request' && env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
+        run: |
+          echo "Listing deployments for branch: $BRANCH_NAME"
+          DEPLOYMENTS=$(npx wrangler pages deployment list --project-name=filetool --environment=preview --json)
+
+          # Use jq to filter deployments for the specific branch and get their IDs
+          # We check if branch matches the PR's head branch in common metadata locations
+          IDS=$(echo "$DEPLOYMENTS" | jq -r ".[] | select(.deployment_trigger.metadata.branch == env.BRANCH_NAME or .meta.branch == env.BRANCH_NAME) | .id")
+
+          if [ -z "$IDS" ]; then
+            echo "No deployments found for branch: $BRANCH_NAME"
+          else
+            for ID in $IDS; do
+              echo "Deleting deployment: $ID"
+              npx wrangler pages deployment delete "$ID" --project-name=filetool --force
+            done
+          fi
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+
       - name: Deploy to Cloudflare Pages
         id: deploy
         if: github.event_name == 'pull_request' && env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
@@ -130,12 +151,29 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.createComment({
+            const body = `🚀 Cloudflare Pages preview is ready! \n\nView it at: ${'${{ steps.deploy.outputs.deployment-url }}'}/filetool/`;
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🚀 Cloudflare Pages preview is ready! \n\nView it at: ${'${{ steps.deploy.outputs.deployment-url }}'}/filetool/`
-            })
+              per_page: 100
+            });
+            const botComment = comments.find(comment => comment.body.includes('🚀 Cloudflare Pages preview is ready!'));
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                comment_id: botComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              });
+            }
 
       - name: Comment on PR if secrets are missing
         if: github.event_name == 'pull_request' && (env.CLOUDFLARE_API_TOKEN == '' || env.CLOUDFLARE_ACCOUNT_ID == '') && github.event.action == 'opened'


### PR DESCRIPTION
This PR modifies the GitHub Actions workflow to ensure only one Cloudflare Pages preview deployment exists per pull request branch at any time. It achieves this by adding a cleanup step before deployment that deletes existing deployments for the branch. Additionally, it updates the "Post preview link" step to find and update the existing PR comment with the latest deployment URL, providing a cleaner PR history.

---
*PR created automatically by Jules for task [5073086170911253446](https://jules.google.com/task/5073086170911253446) started by @mauricelam*