### PR TITLE
Fix HPROF integration tests by using runHandlerTest utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -946,6 +946,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "graphviz-react": "^1.2.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },

--- a/tests/integration/hprof.spec.ts
+++ b/tests/integration/hprof.spec.ts
@@ -1,34 +1,46 @@
 import { test, expect } from '@playwright/test';
+import * as path from 'path';
+import * as fs from 'fs';
+import { runHandlerTest } from './test-utils';
 
 test('HPROF viewer should display file content', async ({ page }) => {
-    // Navigate to the HPROF viewer directly with the test flag
-    await page.goto('http://localhost:8080/filetool/hprof/index.html?test=true');
+    const filePath = path.resolve(__dirname, '../../hprof/test.hprof');
+    const fileContent = fs.readFileSync(filePath);
+
+    const iframe = await runHandlerTest(page, {
+        handler: 'hprof',
+        file: {
+            content: fileContent,
+            name: 'test.hprof',
+            type: ''
+        }
+    });
 
     // Wait for the loading to complete
-    await expect(page.locator('h2')).toContainText('HPROF Viewer: test.hprof', { timeout: 15000 });
+    await expect(iframe.locator('h2')).toContainText('HPROF Viewer: test.hprof', { timeout: 15000 });
 
     // Check if the format and ID size are displayed
-    await expect(page.locator('#output')).toContainText('Format: JAVA PROFILE 1.0.1');
-    await expect(page.locator('#output')).toContainText('ID Size: 4 bytes');
+    await expect(iframe.locator('#output')).toContainText('Format: JAVA PROFILE 1.0.1');
+    await expect(iframe.locator('#output')).toContainText('ID Size: 4 bytes');
 
     // Check if records are listed in the sidebar
-    await expect(page.locator('.record-item').filter({ hasText: 'Utf8' }).first()).toBeVisible();
-    await expect(page.locator('.record-item').filter({ hasText: 'LoadClass' }).first()).toBeVisible();
-    await expect(page.locator('.record-item').filter({ hasText: 'HeapDumpSegment' }).first()).toBeVisible();
+    await expect(iframe.locator('.record-item').filter({ hasText: 'Utf8' }).first()).toBeVisible();
+    await expect(iframe.locator('.record-item').filter({ hasText: 'LoadClass' }).first()).toBeVisible();
+    await expect(iframe.locator('.record-item').filter({ hasText: 'HeapDumpSegment' }).first()).toBeVisible();
 
     // Click on the HeapDumpSegment record and check details
-    await page.locator('.record-item').filter({ hasText: 'HeapDumpSegment' }).first().click();
+    await iframe.locator('.record-item').filter({ hasText: 'HeapDumpSegment' }).first().click();
 
     // Check if details area contains "Heap Dump Summary" (it's in the text content)
-    await expect(page.locator('#output')).toContainText('Heap Dump Summary', { timeout: 10000 });
+    await expect(iframe.locator('#output')).toContainText('Heap Dump Summary', { timeout: 10000 });
 
     // Test Instance Counts tab
-    await page.locator('div').filter({ hasText: /^Instance Counts$/ }).click();
-    await expect(page.locator('table')).toContainText('java.lang.Object', { timeout: 15000 });
-    await expect(page.locator('table')).toContainText('1');
+    await iframe.locator('div').filter({ hasText: /^Instance Counts$/ }).click();
+    await expect(iframe.locator('table')).toContainText('java.lang.Object', { timeout: 15000 });
+    await expect(iframe.locator('table')).toContainText('1');
 
     // Test Reference Graph tab
-    await page.locator('div').filter({ hasText: /^Reference Graph$/ }).click();
+    await iframe.locator('div').filter({ hasText: /^Reference Graph$/ }).click();
     // Graphviz takes time to render
-    await expect(page.locator('svg')).toBeVisible({ timeout: 20000 });
+    await expect(iframe.locator('svg')).toBeVisible({ timeout: 20000 });
 });


### PR DESCRIPTION
Refactored the HPROF integration test to use the `runHandlerTest` utility, which correctly handles the iframe context and file injection, fixing the locator timeout errors.

---
*PR created automatically by Jules for task [16784146173519847494](https://jules.google.com/task/16784146173519847494) started by @mauricelam*